### PR TITLE
fix:color+triggers

### DIFF
--- a/task-bht_bold.psyexp
+++ b/task-bht_bold.psyexp
@@ -264,11 +264,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="1" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x04&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="2.7" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -341,11 +341,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="1" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x04&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="2.7" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -433,11 +433,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="4" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x01&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="0.5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -537,11 +537,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="2" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x08&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="15" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -700,9 +700,9 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="2" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x08&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="15" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
         <Param val="0" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
@@ -757,6 +757,27 @@
         <Param val="False" valType="bool" updates="None" name="disabled"/>
         <Param val="code_3" valType="code" updates="None" name="name"/>
       </CodeComponent>
+      <SerialOutComponent name="all_CH_2" plugin="None">
+        <Param val="9600" valType="int" updates="None" name="baudrate"/>
+        <Param val="8" valType="int" updates="None" name="bytesize"/>
+        <Param val="False" valType="bool" updates="None" name="disabled"/>
+        <Param val="" valType="code" updates="None" name="durationEstim"/>
+        <Param val="False" valType="bool" updates="None" name="getResponse"/>
+        <Param val="all_CH_2" valType="code" updates="None" name="name"/>
+        <Param val="N" valType="str" updates="None" name="parity"/>
+        <Param val="/dev/ttyACM0" valType="str" updates="None" name="port"/>
+        <Param val="True" valType="bool" updates="None" name="saveStartStop"/>
+        <Param val="" valType="code" updates="None" name="startEstim"/>
+        <Param val="time (s)" valType="str" updates="None" name="startType"/>
+        <Param val="0.0" valType="code" updates="None" name="startVal"/>
+        <Param val="$(&quot;\x02&quot;)" valType="str" updates="None" name="startdata"/>
+        <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
+        <Param val="1" valType="int" updates="None" name="stopbits"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
+        <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
+        <Param val="" valType="int" updates="None" name="timeout"/>
+      </SerialOutComponent>
     </Routine>
     <Routine name="stop_et">
       <EyetrackerRecordComponent name="etRecord_2" plugin="None">
@@ -833,6 +854,27 @@
         <Param val="from exp settings" valType="str" updates="None" name="units"/>
         <Param val="" valType="num" updates="constant" name="wrapWidth"/>
       </TextComponent>
+      <SerialOutComponent name="all_CH_3" plugin="None">
+        <Param val="9600" valType="int" updates="None" name="baudrate"/>
+        <Param val="8" valType="int" updates="None" name="bytesize"/>
+        <Param val="False" valType="bool" updates="None" name="disabled"/>
+        <Param val="" valType="code" updates="None" name="durationEstim"/>
+        <Param val="False" valType="bool" updates="None" name="getResponse"/>
+        <Param val="all_CH_3" valType="code" updates="None" name="name"/>
+        <Param val="N" valType="str" updates="None" name="parity"/>
+        <Param val="/dev/ttyACM0" valType="str" updates="None" name="port"/>
+        <Param val="True" valType="bool" updates="None" name="saveStartStop"/>
+        <Param val="" valType="code" updates="None" name="startEstim"/>
+        <Param val="time (s)" valType="str" updates="None" name="startType"/>
+        <Param val="0.0" valType="code" updates="None" name="startVal"/>
+        <Param val="$(&quot;\x02&quot;)" valType="str" updates="None" name="startdata"/>
+        <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
+        <Param val="1" valType="int" updates="None" name="stopbits"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
+        <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
+        <Param val="" valType="int" updates="None" name="timeout"/>
+      </SerialOutComponent>
     </Routine>
     <Routine name="calibration"/>
     <EyetrackerCalibrationRoutine name="calibration_3">
@@ -870,11 +912,11 @@
       <Param name="innerBorderColor" updates="None" val="black" valType="color"/>
       <Param name="innerBorderWidth" updates="None" val="2" valType="num"/>
       <Param name="innerFillColor" updates="None" val="green" valType="color"/>
-      <Param name="innerRadius" updates="None" val="0.035" valType="num"/>
+      <Param name="innerRadius" updates="None" val="0.0075" valType="num"/>
       <Param name="movementAnimation" updates="None" val="True" valType="bool"/>
       <Param name="movementDur" updates="None" val="1.0" valType="num"/>
       <Param name="name" updates="None" val="calibration_2" valType="code"/>
-      <Param name="outerRadius" updates="None" val="0.075" valType="num"/>
+      <Param name="outerRadius" updates="None" val="0.015" valType="num"/>
       <Param name="progressMode" updates="None" val="time" valType="str"/>
       <Param name="randomisePos" updates="None" val="True" valType="bool"/>
       <Param name="targetDelay" updates="None" val="1.0" valType="num"/>

--- a/task-pct_bold.psyexp
+++ b/task-pct_bold.psyexp
@@ -155,9 +155,9 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="1" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x02&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="0.5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
         <Param val="0" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
@@ -235,10 +235,10 @@
         <Param val="1" valType="num" updates="constant" name="contrast"/>
         <Param val="False" valType="bool" updates="None" name="disabled"/>
         <Param val="" valType="code" updates="None" name="durationEstim"/>
-        <Param val="$[1,-1,-1]" valType="str" updates="constant" name="fillColor"/>
+        <Param val="$[-1,1,-1]" valType="str" updates="constant" name="fillColor"/>
         <Param val="rgb" valType="str" updates="constant" name="fillColorSpace"/>
         <Param val="linear" valType="str" updates="constant" name="interpolate"/>
-        <Param val="$[1,-1,-1]" valType="str" updates="constant" name="lineColor"/>
+        <Param val="$[-1,-1,-1]" valType="str" updates="constant" name="lineColor"/>
         <Param val="rgb" valType="str" updates="constant" name="lineColorSpace"/>
         <Param val="1" valType="code" updates="constant" name="lineWidth"/>
         <Param val="4" valType="int" updates="constant" name="nVertices"/>
@@ -271,11 +271,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="2" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x04&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="3" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -307,7 +307,7 @@
         <Param val="$[0,0,0]" valType="str" updates="constant" name="fillColor"/>
         <Param val="rgb" valType="str" updates="constant" name="fillColorSpace"/>
         <Param val="linear" valType="str" updates="constant" name="interpolate"/>
-        <Param val="$[-1,1,-1]" valType="str" updates="constant" name="lineColor"/>
+        <Param val="$[-1,-1,-1]" valType="str" updates="constant" name="lineColor"/>
         <Param val="rgb" valType="str" updates="constant" name="lineColorSpace"/>
         <Param val="2" valType="code" updates="constant" name="lineWidth"/>
         <Param val="4" valType="int" updates="constant" name="nVertices"/>
@@ -340,11 +340,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="4" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x08&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="0.5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -371,9 +371,9 @@
         <Param val="1" valType="num" updates="constant" name="contrast"/>
         <Param val="False" valType="bool" updates="None" name="disabled"/>
         <Param val="" valType="code" updates="None" name="durationEstim"/>
-        <Param val="$[1,-1,-1]" valType="str" updates="constant" name="fillColor"/>
+        <Param val="$[-1,1,-1]" valType="str" updates="constant" name="fillColor"/>
         <Param val="linear" valType="str" updates="constant" name="interpolate"/>
-        <Param val="$[-1,1,-1]" valType="str" updates="constant" name="lineColor"/>
+        <Param val="$[-1,-1,-1]" valType="str" updates="constant" name="lineColor"/>
         <Param val="2" valType="code" updates="constant" name="lineWidth"/>
         <Param val="4" valType="int" updates="constant" name="nVertices"/>
         <Param val="eye_movement_fixation_inner" valType="code" updates="None" name="name"/>
@@ -403,7 +403,7 @@
         <Param val="$[0,0,0]" valType="str" updates="constant" name="fillColor"/>
         <Param val="rgb" valType="str" updates="constant" name="fillColorSpace"/>
         <Param val="linear" valType="str" updates="constant" name="interpolate"/>
-        <Param val="$[-1,1,-1]" valType="str" updates="constant" name="lineColor"/>
+        <Param val="$[-1,-1,-1]" valType="str" updates="constant" name="lineColor"/>
         <Param val="rgb" valType="str" updates="constant" name="lineColorSpace"/>
         <Param val="2" valType="code" updates="constant" name="lineWidth"/>
         <Param val="4" valType="int" updates="constant" name="nVertices"/>
@@ -436,11 +436,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="16" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x20&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="3" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -467,7 +467,7 @@
         <Param val="1" valType="num" updates="constant" name="contrast"/>
         <Param val="False" valType="bool" updates="None" name="disabled"/>
         <Param val="" valType="code" updates="None" name="durationEstim"/>
-        <Param val="$[1,-1,-1]" valType="str" updates="constant" name="fillColor"/>
+        <Param val="$[-1,1,-1]" valType="str" updates="constant" name="fillColor"/>
         <Param val="rgb" valType="str" updates="constant" name="fillColorSpace"/>
         <Param val="linear" valType="str" updates="constant" name="interpolate"/>
         <Param val="$[-1,-1,-1]" valType="str" updates="constant" name="lineColor"/>
@@ -704,11 +704,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="1" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x03&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="0.5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -752,11 +752,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="8" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x10&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -849,11 +849,11 @@
       <Param name="innerBorderColor" updates="None" val="black" valType="color"/>
       <Param name="innerBorderWidth" updates="None" val="2" valType="num"/>
       <Param name="innerFillColor" updates="None" val="green" valType="color"/>
-      <Param name="innerRadius" updates="None" val="0.035" valType="num"/>
+      <Param name="innerRadius" updates="None" val="0.0075" valType="num"/>
       <Param name="movementAnimation" updates="None" val="True" valType="bool"/>
       <Param name="movementDur" updates="None" val="1.0" valType="num"/>
       <Param name="name" updates="None" val="calibration" valType="code"/>
-      <Param name="outerRadius" updates="None" val="0.075" valType="num"/>
+      <Param name="outerRadius" updates="None" val="0.015" valType="num"/>
       <Param name="progressMode" updates="None" val="time" valType="str"/>
       <Param name="randomisePos" updates="None" val="False" valType="bool"/>
       <Param name="targetDelay" updates="None" val="1.0" valType="num"/>

--- a/task-rest_bold.psyexp
+++ b/task-rest_bold.psyexp
@@ -119,11 +119,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="0.0" valType="code" updates="None" name="startVal"/>
-        <Param val="1" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x03&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="0.5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -140,11 +140,11 @@
         <Param val="" valType="code" updates="None" name="startEstim"/>
         <Param val="time (s)" valType="str" updates="None" name="startType"/>
         <Param val="1200" valType="code" updates="None" name="startVal"/>
-        <Param val="1" valType="str" updates="None" name="startdata"/>
+        <Param val="$(&quot;\x02&quot;)" valType="str" updates="None" name="startdata"/>
         <Param val="duration (s)" valType="str" updates="None" name="stopType"/>
-        <Param val="0.5" valType="code" updates="constant" name="stopVal"/>
+        <Param val="0.008" valType="code" updates="constant" name="stopVal"/>
         <Param val="1" valType="int" updates="None" name="stopbits"/>
-        <Param val="0" valType="str" updates="None" name="stopdata"/>
+        <Param val="" valType="str" updates="None" name="stopdata"/>
         <Param val="False" valType="bool" updates="None" name="syncScreenRefresh"/>
         <Param val="" valType="int" updates="None" name="timeout"/>
       </SerialOutComponent>
@@ -250,11 +250,11 @@
       <Param name="innerBorderColor" updates="None" val="black" valType="color"/>
       <Param name="innerBorderWidth" updates="None" val="2" valType="num"/>
       <Param name="innerFillColor" updates="None" val="green" valType="color"/>
-      <Param name="innerRadius" updates="None" val="0.035" valType="num"/>
+      <Param name="innerRadius" updates="None" val="0.0075" valType="num"/>
       <Param name="movementAnimation" updates="None" val="True" valType="bool"/>
       <Param name="movementDur" updates="None" val="1.0" valType="num"/>
       <Param name="name" updates="None" val="calibration" valType="code"/>
-      <Param name="outerRadius" updates="None" val="0.075" valType="num"/>
+      <Param name="outerRadius" updates="None" val="0.015" valType="num"/>
       <Param name="progressMode" updates="None" val="time" valType="str"/>
       <Param name="randomisePos" updates="None" val="True" valType="bool"/>
       <Param name="targetDelay" updates="None" val="1.0" valType="num"/>


### PR DESCRIPTION
- fixes the values of the triggers sent to the acknowledge software by psychopy.
- fixes the color of the dots in PCT and calibration.